### PR TITLE
Implement better auth mechanism, use MessagePack to marshal data

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -4,114 +4,58 @@ import (
 	"bytes"
 	"crypto/ecdsa"
 	"crypto/elliptic"
-	"crypto/rand"
 	"crypto/sha256"
-	"encoding/base64"
 	"log"
 	"math/big"
+	"strconv"
+	"time"
 )
 
-const CHALLENGE_LEN = 32
-
-type Challenge struct {
-	Txt string `json:"txt"`
-	Sig string `json:"sig"`
-}
-
-type ChallengeWrapper struct {
-	Challenge Challenge `json:"challenge"`
-}
-
-func genRandomBytes(size int) (blk []byte, err error) {
-	blk = make([]byte, size)
-	_, err = rand.Read(blk)
+func VerifyAuthMessage(msg *AuthMessage, id []byte) bool {
+	// verify Time is within 1 second
+	threshold := time.Duration(1) * time.Second
+	timestamp, err := strconv.ParseInt(string(msg.Time), 10, 64)
 	if err != nil {
-		log.Println(err)
+		log.Println("failed to convert time to int")
 	}
-	return
-}
+	timeDec := time.UnixMilli(timestamp)
 
-func GetChallenge(priv *ecdsa.PrivateKey) (ChallengeWrapper, error) {
-	randBytes, err := genRandomBytes(CHALLENGE_LEN)
-	if err != nil {
-		return ChallengeWrapper{}, err
-	}
-	h := sha256.New()
-	h.Write(randBytes)
-	randBytesHash := h.Sum(nil)
-	prng := rand.Reader
-	r, s, err := ecdsa.Sign(prng, priv, randBytesHash)
-	if err != nil {
-		return ChallengeWrapper{}, err
-	}
-	sigBytes := []byte{}
-	sigBytes = append(sigBytes, r.Bytes()...)
-	sigBytes = append(sigBytes, s.Bytes()...)
-	sigStr := base64.RawURLEncoding.EncodeToString(sigBytes)
-	txt := base64.RawURLEncoding.EncodeToString(randBytesHash)
-	chall := Challenge{txt, sigStr}
-	return ChallengeWrapper{Challenge: chall}, nil
-}
-
-func VerifySolution(msg *ClientMessage, id []byte, sPub *ecdsa.PublicKey) bool {
-	// decode client public key
-	cPubBytes, err := base64.RawURLEncoding.DecodeString(msg.PublicKey)
-	if err != nil {
-		log.Println(err)
-		return false
+	if timeDec.Before(time.Now()) {
+		// check if not too old
+		if timeDec.Add(threshold).Before(time.Now()) {
+			return false
+		}
+	} else {
+		// check if not too far in future
+		if time.Now().Add(threshold).Before(timeDec) {
+			return false
+		}
 	}
 
 	// check id equals SHA-256 of public Key
 	h := sha256.New()
-	h.Write(cPubBytes)
-	cPubHash := h.Sum(nil)
-	if !bytes.Equal(id, cPubHash) {
-		log.Println("public key does not match id", id, cPubHash)
-		return false
-	}
-
-	// decode challenge
-	txt, err := base64.RawURLEncoding.DecodeString(msg.Challenge.Txt)
-	if err != nil {
-		log.Println(err)
-		return false
-	}
-
-	// verify server signature
-	sSig, err := base64.RawURLEncoding.DecodeString(msg.Challenge.Sig)
-	if err != nil {
-		log.Println(err)
-		return false
-	}
-	sL := len(sSig) / 2
-	sSigR := new(big.Int).SetBytes(sSig[:sL])
-	sSigS := new(big.Int).SetBytes(sSig[sL:])
-	sValid := ecdsa.Verify(sPub, txt, sSigR, sSigS)
-	if !sValid {
-		log.Println("server signature invalid")
+	h.Write(msg.PublicKey)
+	pubHash := h.Sum(nil)
+	if !bytes.Equal(id, pubHash) {
+		log.Println("public key does not match id", id, pubHash)
 		return false
 	}
 
 	// unmarshal client public key
-	cPub := ecdsa.PublicKey{
+	pubKey := ecdsa.PublicKey{
 		Curve: elliptic.P256(),
-		X:     new(big.Int).SetBytes(cPubBytes[1:33]),
-		Y:     new(big.Int).SetBytes(cPubBytes[33:])}
+		X:     new(big.Int).SetBytes(msg.PublicKey[1:33]),
+		Y:     new(big.Int).SetBytes(msg.PublicKey[33:])}
+
+	// hash Time with SHA-256
+	tH := sha256.New()
+	tH.Write(msg.Time)
+	tHash := tH.Sum(nil)
 
 	// verify client signature
-	cSig, err := base64.RawURLEncoding.DecodeString(msg.Solution)
-	if err != nil {
-		log.Println(err)
-		return false
-	}
-	cL := len(cSig) / 2
-	cSigR := new(big.Int).SetBytes(cSig[:cL])
-	cSigS := new(big.Int).SetBytes(cSig[cL:])
+	cL := len(msg.Sig) / 2
+	cSigR := new(big.Int).SetBytes(msg.Sig[:cL])
+	cSigS := new(big.Int).SetBytes(msg.Sig[cL:])
 
-	// hash challenge with SHA-256
-	txtH := sha256.New()
-	txtH.Write(txt)
-	txtHash := txtH.Sum(nil)
-
-	return ecdsa.Verify(&cPub, txtHash, cSigR, cSigS)
+	return ecdsa.Verify(&pubKey, tHash, cSigR, cSigS)
 }

--- a/auth.go
+++ b/auth.go
@@ -11,6 +11,12 @@ import (
 	"time"
 )
 
+type AuthMessage struct {
+	Time      []byte `msgpack:"time"`
+	Sig       []byte `msgpack:"sig"`
+	PublicKey []byte `msgpack:"publicKey"`
+}
+
 func VerifyAuthMessage(msg *AuthMessage, id []byte) bool {
 	// verify Time is within 1 second
 	threshold := time.Duration(1) * time.Second
@@ -19,7 +25,6 @@ func VerifyAuthMessage(msg *AuthMessage, id []byte) bool {
 		log.Println("failed to convert time to int")
 	}
 	timeDec := time.UnixMilli(timestamp)
-
 	if timeDec.Before(time.Now()) {
 		// check if not too old
 		if timeDec.Add(threshold).Before(time.Now()) {

--- a/connection.go
+++ b/connection.go
@@ -12,22 +12,16 @@ import (
 	"github.com/shamaton/msgpack/v2"
 )
 
-type ServerResponse struct {
-	Message  interface{} `json:"message"`
-	VapidKey interface{} `json:"vapidKey"`
-	Data     interface{} `json:"data"`
-	Error    interface{} `json:"error"`
+type Response struct {
+	Message  interface{} `msgpack:"message"`
+	VapidKey interface{} `msgpack:"vapidKey"`
+	Data     []byte      `msgpack:"data"`
+	Error    interface{} `msgpack:"error"`
 }
 
-type DataMessage struct {
-	Subscription webpush.Subscription `msgpack:"sub"`
-	Data         string               `msgpack:"data"`
-}
-
-type AuthMessage struct {
-	Time      []byte `msgpack:"t"`
-	Sig       []byte `msgpack:"sig"`
-	PublicKey []byte `msgpack:"pubKey"`
+type Message struct {
+	PushSubscription string `msgpack:"sub"`
+	Data             []byte `msgpack:"data"`
 }
 
 func HandleConnection(w http.ResponseWriter, r *http.Request, o *Oracle, opt *Options) {
@@ -72,83 +66,88 @@ func HandleConnection(w http.ResponseWriter, r *http.Request, o *Oracle, opt *Op
 			return
 		}
 		if authMsgType != websocket.BinaryMessage {
+			msg, _ := msgpack.Marshal(Response{
+				Message: "send only binary data serialised with msgpack",
+				Error:   "invalid message type",
+			})
+			conn.WriteMessage(websocket.BinaryMessage, msg)
 			return
 		}
 		var authMsg AuthMessage
 		err = msgpack.Unmarshal(authMsgBin, &authMsg)
 		if err != nil {
 			log.Println("failed to unmarshal auth", err)
+			msg, _ := msgpack.Marshal(Response{
+				Message: "failed to unmarshal message",
+				Error:   err.Error(),
+			})
+			conn.WriteMessage(websocket.BinaryMessage, msg)
 			return
 		}
-
-		// verify auth msg
 		if !VerifyAuthMessage(&authMsg, id) {
+			msg, _ := msgpack.Marshal(Response{
+				Error: "unauthorized",
+			})
+			conn.WriteMessage(websocket.BinaryMessage, msg)
 			return
 		}
 
-		// user is authed
 		user, err := o.GetUser(idEnc)
 		if err != nil {
 			log.Println("failed to find user", idEnc)
 			return
 		}
+
 		user.Pusher.EnsureKey()
-		r := ServerResponse{
-			Message:  "handshake done",
+
+		resp := Response{
+			Message:  "authed",
 			VapidKey: user.Pusher.PublicKey,
 			Data:     user.GetData(),
 		}
-		rj, _ := json.Marshal(r)
-		err = conn.WriteMessage(websocket.TextMessage, rj)
-		if err != nil {
-			log.Println(err)
-			return
-		}
+		respBin, _ := msgpack.Marshal(resp)
+		conn.WriteMessage(websocket.BinaryMessage, respBin)
+
 		user.RegisterWebSocket(conn)
 		user.SendStored()
 
-		// authenticated message loop
+		// authed msg loop
 		for {
-			msgType, msgText, err := conn.ReadMessage()
-
+			msgType, msgBin, err := conn.ReadMessage()
 			if err != nil {
 				conn.Close()
 				return
 			}
 
-			if msgType != websocket.TextMessage {
-				log.Println("bad message", msgType, msgText)
-				return
-			}
-
-			var msg DataMessage
-			err = json.Unmarshal(msgText, &msg)
-			if err != nil {
-				log.Println("failed to unmarshal message", err)
-				return
-			}
-
-			if msg.Subscription.Endpoint != "" {
-				user.Pusher.AddSubscription(&msg.Subscription)
-			}
-
-			/*if msg.Get == "data" {
-				resp, _ := json.Marshal(ServerResponse{
-					Data: user.GetData(),
+			if msgType != websocket.BinaryMessage {
+				msg, _ := msgpack.Marshal(Response{
+					Message: "send only binary data serialised with msgpack",
+					Error:   "invalid message type",
 				})
-				conn.WriteMessage(websocket.TextMessage, resp)
+				conn.WriteMessage(websocket.BinaryMessage, msg)
+				return
 			}
 
-			if msg.Set == "data" {
-				err := user.SetData(msg.Data, opt.DataLenMax)
+			var msg Message
+			err = msgpack.Unmarshal(msgBin, &msg)
+			if err != nil {
+				log.Println("failed to unmarshal msg", err)
+				return
+			}
+
+			if msg.PushSubscription != "" {
+				log.Println("got sub", msg.PushSubscription)
+				sub := webpush.Subscription{}
+				err := json.Unmarshal([]byte(msg.PushSubscription), &sub)
 				if err != nil {
-					log.Println("failed to set data", err)
-					errResp, _ := json.Marshal(ServerResponse{
-						Error: fmt.Sprintf("%v", err),
-					})
-					conn.WriteMessage(websocket.TextMessage, errResp)
+					log.Println("failed to unmarshal push subscription")
 				}
-			}*/
+				user.Pusher.AddSubscription(&sub)
+			}
+
+			if msg.Data != nil && len(msg.Data) <= opt.DataLenMax {
+				user.SetData(msg.Data)
+			}
 		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	github.com/SherClockHolmes/webpush-go v1.1.3
 	github.com/gorilla/websocket v1.4.2
+	github.com/shamaton/msgpack/v2 v2.1.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keL
 github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/shamaton/msgpack/v2 v2.1.0 h1:9jJ2eGZw2Wa9KExPX3KaDDckVjgr4zhXGFCfWagUWqg=
+github.com/shamaton/msgpack/v2 v2.1.0/go.mod h1:aTUEmh31ziGX1Ml7wMPLVY0f4vT3CRsCvZRoSCs+VGg=
 golang.org/x/crypto v0.0.0-20190131182504-b8fe1690c613/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20220112180741-5e0467b6c7ce h1:Roh6XWxHFKrPgC/EQhVubSAGQ6Ozk6IdxHSzt1mR0EI=
 golang.org/x/crypto v0.0.0-20220112180741-5e0467b6c7ce/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=

--- a/oracle.go
+++ b/oracle.go
@@ -61,7 +61,7 @@ func (o *Oracle) KeepClean() {
 			// has no push subscription &&
 			// has no stored data )
 			if !u.Online && (time.Now().After(u.LastConnection.Add(o.Options.UserTTL)) ||
-				len(keep) < 1 && u.Pusher.Subscription == nil && u.Data == "") {
+				len(keep) < 1 && u.Pusher.Subscription == nil && u.Data != nil) {
 				delete(o.Users, id)
 				log.Println("cleaned up", id)
 			} else {

--- a/post.go
+++ b/post.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"io"
 	"net/http"
 )
@@ -9,18 +8,15 @@ import (
 func HandlePost(w http.ResponseWriter, r *http.Request, o *Oracle) {
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
-		http.Error(w, "error reading body", http.StatusBadRequest)
+		http.Error(w, "failed to read body", http.StatusBadRequest)
 		return
 	}
 	r.Body.Close()
 	id := GetIdFromPath(r.URL.Path)
 	user, err := o.GetUser(id)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		http.Error(w, "failed to get user", http.StatusBadRequest)
 		return
 	}
 	user.Send(body, o.Options.MsgTTL)
-	resp := ServerResponse{Message: "sent"}
-	rj, _ := json.Marshal(resp)
-	w.Write(rj)
 }

--- a/user.go
+++ b/user.go
@@ -24,22 +24,10 @@ type Msg struct {
 	Kick time.Time // time to kick from storage
 }
 
-type MessageBody struct {
-	From []byte `msgpack:"f"`
-}
-
 type Connection struct {
 	Sock *websocket.Conn
 	Mux  *sync.Mutex
 }
-
-/*
-Type: "message"
-From: "{publicKeyHash}"
-type Notification struct {
-	Type string
-	From string
-}*/
 
 func (u *User) RegisterWebSocket(conn *websocket.Conn) {
 	c := Connection{
@@ -81,7 +69,7 @@ func (u *User) Send(msg []byte, ttl time.Duration) {
 	if u.Online {
 		for _, c := range u.Conns {
 			c.Mux.Lock()
-			err := c.Sock.WriteMessage(websocket.TextMessage, msg)
+			err := c.Sock.WriteMessage(websocket.BinaryMessage, msg)
 			c.Mux.Unlock()
 			if err != nil {
 				log.Println(c.Sock.RemoteAddr(), "failed to send msg", err)
@@ -89,11 +77,7 @@ func (u *User) Send(msg []byte, ttl time.Duration) {
 		}
 	} else { // offline
 		// send notification
-		u.Pusher.Push(u.Id, []byte("You've got a message"))
-		/*
-			TODO: Unmarshal received msg, get 'from' id
-			& serialise rich notification
-		*/
+		u.Pusher.Push(u.Id, []byte("Received message"))
 	}
 }
 


### PR DESCRIPTION
Rather than the initial lengthy, complex & stateful auth mechanism here is a much simpler one, with better security.

Also, I was fed up with all of the encoding/decoding between bytes & base64. To simplify everything, the client & server will now use MessagePack to serialise data, and send only binary messages.

So...much less code, much less complexity, much less bloat.